### PR TITLE
Add SOC analyst prompt templates

### DIFF
--- a/prompt-templates/README.md
+++ b/prompt-templates/README.md
@@ -1,0 +1,18 @@
+# Prompt Templates for SOC Analyst Agent
+
+This folder contains example prompt templates for guiding an L1/2 SOC analyst agent. Each template focuses on a common task that a first or second level analyst may need to perform when using Splunk and web research.
+
+## Available Templates
+
+- `alert-triage.md` - Initial review of a new alert.
+- `false-positive-check.md` - Verify whether an alert is a false positive.
+- `splunk-search.md` - Craft or explain Splunk search queries.
+- `web-research.md` - Steps to research indicators on the web.
+- `incident-documentation.md` - Record actions taken during an investigation.
+- `escalation.md` - Provide information required to escalate an incident.
+- `threat-hunting.md` - Conduct hypothesis-driven hunting in Splunk.
+- `dashboards.md` - Review Splunk dashboards for anomalies.
+- `daily-summary.md` - Summarize notable events for the day.
+- `ioc-investigation.md` - Investigate a specific indicator of compromise.
+
+These templates can be customized with variables such as `{alert_id}`, `{splunk_query}`, or `{indicator}` to generate clear instructions for the analyst agent.

--- a/prompt-templates/alert-triage.md
+++ b/prompt-templates/alert-triage.md
@@ -1,0 +1,13 @@
+# Alert Triage
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Review the incoming alert details and determine if immediate action is required.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Using Splunk, review the alert with ID {alert_id} generated at {time}. Summarize the key fields, assess severity, and determine if the alert is actionable. Provide:
+- A short summary of what triggered the alert
+- The severity level
+- Recommended next steps
+```

--- a/prompt-templates/daily-summary.md
+++ b/prompt-templates/daily-summary.md
@@ -1,0 +1,13 @@
+# Daily Summary Report
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Provide a summary of notable events for the day.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Summarize today's notable security events observed in Splunk and from web research. Include:
+- Key incidents investigated
+- Trends or patterns
+- Any open items requiring follow up
+```

--- a/prompt-templates/dashboards.md
+++ b/prompt-templates/dashboards.md
@@ -1,0 +1,10 @@
+# Dashboard Review
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Evaluate Splunk dashboards for notable events and trends.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Review the Splunk dashboard {dashboard_name}. Identify any spikes or anomalies in the data. Describe what each panel shows and note any suspicious activity that should be investigated further.
+```

--- a/prompt-templates/escalation.md
+++ b/prompt-templates/escalation.md
@@ -1,0 +1,15 @@
+# Escalation Instructions
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Escalate an incident with all required details for higher-tier review.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Prepare an escalation summary for incident {incident_id} including:
+- Timeline of events
+- Severity assessment
+- Key indicators
+- Steps already taken
+Provide a concise recommendation for further action and assign to the appropriate team.
+```

--- a/prompt-templates/false-positive-check.md
+++ b/prompt-templates/false-positive-check.md
@@ -1,0 +1,12 @@
+# False Positive Check
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Determine if a triggered alert is a false positive using Splunk searches and contextual information.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Investigate alert {alert_id} by running the provided Splunk search:
+{splunk_query}
+Document whether the alert is a true or false positive. Note indicators that support your decision and recommend action if required.
+```

--- a/prompt-templates/incident-documentation.md
+++ b/prompt-templates/incident-documentation.md
@@ -1,0 +1,15 @@
+# Incident Documentation
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Record findings and actions taken during investigation.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Document the incident {incident_id} including:
+- Summary of events
+- Splunk searches performed
+- Evidence collected
+- Recommended remediation
+Provide enough detail for another analyst to understand the actions taken.
+```

--- a/prompt-templates/ioc-investigation.md
+++ b/prompt-templates/ioc-investigation.md
@@ -1,0 +1,13 @@
+# IOC Investigation
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Investigate an indicator of compromise (IOC) using Splunk and web research.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Investigate the indicator {indicator}. Steps:
+1. Run Splunk searches to find occurrences of the IOC.
+2. Research the IOC with open-source references.
+3. Summarize findings and assess risk.
+```

--- a/prompt-templates/splunk-search.md
+++ b/prompt-templates/splunk-search.md
@@ -1,0 +1,12 @@
+# Splunk Search Guidance
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Craft an efficient Splunk search to locate relevant events.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Create a Splunk search that will identify events matching the following criteria:
+{criteria}
+Explain each part of the query and how it filters data. Provide at least one example result field to review.
+```

--- a/prompt-templates/threat-hunting.md
+++ b/prompt-templates/threat-hunting.md
@@ -1,0 +1,12 @@
+# Threat Hunting
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Search for suspicious activity based on a given hypothesis.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Using Splunk, perform threat hunting for the following hypothesis:
+{hypothesis}
+Provide the search strings used, summarize any suspicious findings, and note if further investigation is required.
+```

--- a/prompt-templates/web-research.md
+++ b/prompt-templates/web-research.md
@@ -1,0 +1,10 @@
+# Web Research Steps
+
+**Role:** L1/2 SOC Analyst
+
+**Objective:** Gather context about an indicator from open web resources.
+
+**Template:**
+```
+You are an L1/2 SOC analyst. Research the indicator {indicator} using reliable web sources. Summarize reputation, related malicious activity, and known associations. List references for each source consulted.
+```


### PR DESCRIPTION
## Summary
- add a new `prompt-templates` folder
- create example templates for L1/2 SOC analyst tasks using Splunk and web research
- document available templates in README

## Testing
- `git status --short`