### PR TITLE
Add log emitter

### DIFF
--- a/emitter/.gitignore
+++ b/emitter/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/emitter/Dockerfile
+++ b/emitter/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json tsconfig.json jest.config.js README.md ./
+RUN npm install
+COPY src ./src
+COPY tests ./tests
+RUN npm run build && npm test
+CMD ["node", "dist/index.js"]

--- a/emitter/README.md
+++ b/emitter/README.md
@@ -1,0 +1,20 @@
+# Log Emitter
+
+This tool emits log events to a specified HTTP destination. It is intended for testing logging platforms.
+
+## Usage
+
+```
+npm install
+npm run build
+node dist/index.js --url http://localhost:3000 --format cloudwatch --interval 1000
+```
+
+### Options
+
+- `--url` (required): HTTP endpoint to post logs to.
+- `--format`: `cloudwatch`, `elastic`, or `otel`. Default is `cloudwatch`.
+- `--interval`: Interval between log events in milliseconds. Default is `1000`.
+- `--message`: Message to include in each log. Default is `"test log"`.
+
+The emitter currently supports one stream at a time but is structured to allow multiple streams in the future.

--- a/emitter/jest.config.js
+++ b/emitter/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts']
+};

--- a/emitter/package.json
+++ b/emitter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "log-emitter",
+  "version": "0.1.0",
+  "description": "Simple log emitter for testing log pipelines",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "commander": "^10.0.0",
+    "node-fetch": "^3.3.1"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.2",
+    "@types/node": "^20.0.0",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/emitter/src/formats.ts
+++ b/emitter/src/formats.ts
@@ -1,0 +1,24 @@
+export interface LogObject {
+  [key: string]: any;
+}
+
+export function formatCloudWatch(message: string): LogObject {
+  return {
+    timestamp: Date.now(),
+    message,
+  };
+}
+
+export function formatElastic(message: string): LogObject {
+  return {
+    '@timestamp': new Date().toISOString(),
+    message,
+  };
+}
+
+export function formatOtel(message: string): LogObject {
+  return {
+    timeUnixNano: (Date.now() * 1_000_000).toString(),
+    body: message,
+  };
+}

--- a/emitter/src/index.ts
+++ b/emitter/src/index.ts
@@ -1,0 +1,52 @@
+import { Command } from 'commander';
+import fetch from 'node-fetch';
+import { formatCloudWatch, formatElastic, formatOtel, LogObject } from './formats';
+
+const program = new Command();
+
+program
+  .requiredOption('-u, --url <url>', 'HTTP destination URL')
+  .option('-f, --format <format>', 'log format: cloudwatch|elastic|otel', 'cloudwatch')
+  .option('-i, --interval <ms>', 'interval between logs in ms', '1000')
+  .option('-m, --message <msg>', 'log message', 'test log');
+
+program.parse(process.argv);
+
+const opts = program.opts();
+
+function selectFormatter(fmt: string): (msg: string) => LogObject {
+  switch (fmt) {
+    case 'cloudwatch':
+      return formatCloudWatch;
+    case 'elastic':
+      return formatElastic;
+    case 'otel':
+      return formatOtel;
+    default:
+      throw new Error(`unsupported format: ${fmt}`);
+  }
+}
+
+const formatter = selectFormatter(opts.format);
+const interval = parseInt(opts.interval, 10);
+
+async function sendLog() {
+  const payload = formatter(opts.message);
+  try {
+    const res = await fetch(opts.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      console.error(`failed to send log: ${res.status}`);
+    } else {
+      console.log(`sent log to ${opts.url}`);
+    }
+  } catch (err) {
+    console.error('error sending log', err);
+  }
+}
+
+setInterval(sendLog, interval);
+console.log(`emitting ${opts.format} logs to ${opts.url} every ${interval}ms`);

--- a/emitter/tests/formats.test.ts
+++ b/emitter/tests/formats.test.ts
@@ -1,0 +1,21 @@
+import { formatCloudWatch, formatElastic, formatOtel } from '../src/formats';
+
+describe('log formatters', () => {
+  it('cloudwatch format includes timestamp and message', () => {
+    const result = formatCloudWatch('hello');
+    expect(result).toHaveProperty('timestamp');
+    expect(result).toHaveProperty('message', 'hello');
+  });
+
+  it('elastic format includes @timestamp and message', () => {
+    const result = formatElastic('hello');
+    expect(result).toHaveProperty('@timestamp');
+    expect(result).toHaveProperty('message', 'hello');
+  });
+
+  it('otel format includes timeUnixNano and body', () => {
+    const result = formatOtel('hello');
+    expect(result).toHaveProperty('timeUnixNano');
+    expect(result).toHaveProperty('body', 'hello');
+  });
+});

--- a/emitter/tsconfig.json
+++ b/emitter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add an `emitter` folder with a simple TypeScript log emitter
- support CloudWatch, Elastic, and OTEL log formats
- include Dockerfile and basic Jest tests

## Testing
- `npm test` *(fails: `jest` not found)*